### PR TITLE
Remove reference to default credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To install the SQL CLI:
 1. To launch the CLI, run:
 
     ```
-    opensearchsql https://localhost:9200 --username admin --password admin
+    opensearchsql https://localhost:9200 --username admin --password < Admin password >
     ```
     By default, the `opensearchsql` command connects to [http://localhost:9200](http://localhost:9200/).
 
@@ -107,7 +107,7 @@ For a list of all available configurations, see [clirc](https://github.com/opens
 2. Index the sample data.
 
     ```
-    curl -H "Content-Type: application/x-ndjson" -POST https://localhost:9200/data/_bulk -u admin:admin --insecure --data-binary "@accounts.json"
+    curl -H "Content-Type: application/x-ndjson" -POST https://localhost:9200/data/_bulk -u admin:< Admin password > --insecure --data-binary "@accounts.json"
     ```
 
 


### PR DESCRIPTION
### Description
Starting in Opensearch 2.12.0 release, the security plugin requires an initial admin password to be set. Thus, replacing documentation suggesting that admin is the default password. 
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).