### PR TITLE
Bump boto3 to 1.34.34

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ install_requirements = [
     "cli_helpers[styles] == 1.2.1",
     "opensearch-py == 1.0.0",
     "pyfiglet == 0.8.post1",
-    "boto3 == 1.16.29",
+    "boto3 == 1.34.34",
     "requests-aws4auth == 1.2.3",
 ]
 


### PR DESCRIPTION
### Description
This is to fix the doctest github action in sql plugin which failed since last Dec.

```
> Task :doctest:doctest FAILED
======================================================================
ERROR: test_docs (unittest.loader._FailedTest.test_docs)
----------------------------------------------------------------------
ImportError: Failed to import test module: test_docs
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/unittest/loader.py", line 137, in loadTestsFromName
    module = __import__(module_name)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/sql/sql/doctest/test_docs.py", line 16, in <module>
    from opensearch_sql_cli.opensearch_connection import OpenSearchConnection
  File "/Users/runner/work/sql/sql/doctest/sql-cli/src/opensearch_sql_cli/opensearch_connection.py", line 6, in <module>
    import boto3
  File "/Users/runner/work/sql/sql/doctest/.venv/lib/python3.12/site-packages/boto3/__init__.py", line 16, in <module>
    from boto3.session import Session
  File "/Users/runner/work/sql/sql/doctest/.venv/lib/python3.12/site-packages/boto3/session.py", line 17, in <module>
    import botocore.session
  File "/Users/runner/work/sql/sql/doctest/.venv/lib/python3.12/site-packages/botocore/session.py", line 29, in <module>
    import botocore.configloader
  File "/Users/runner/work/sql/sql/doctest/.venv/lib/python3.12/site-packages/botocore/configloader.py", line 19, in <module>
    from botocore.compat import six
  File "/Users/runner/work/sql/sql/doctest/.venv/lib/python3.12/site-packages/botocore/compat.py", line 33, in <module>
    from botocore.vendored.six.moves import http_client
ModuleNotFoundError: No module named 'botocore.vendored.six.moves'
```

Root cause:
Boto3 has removed six in its later versions: https://github.com/boto/botocore/pull/2806. However, the cli plugin is still utilizing a stale version. Furthermore, opensearch-py uses boto3 version 1.28 or higher. https://github.com/opensearch-project/opensearch-py/blob/94e33c68990fc62906f2dc7239c1eeb2eae3b79e/samples/pyproject.toml#L12

Verification:
This change is tested on sql plugin where all CI passed https://github.com/opensearch-project/sql/pull/2499
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
  - [x] New functionality has javadoc added
  - [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).