### PR TITLE
Update dependencies for newer Python installs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,12 @@ install_requirements = [
     "click == 7.1.2",
     "prompt_toolkit == 2.0.6",
     "Pygments == 2.15.1",
-    "cli_helpers[styles] == 1.2.1",
+    "cli_helpers[styles] == 2.3.0",
     "opensearch-py == 1.0.0",
     "pyfiglet == 0.8.post1",
     "boto3 == 1.34.34",
     "requests-aws4auth == 1.2.3",
+    "setuptools == 74.1.2",
 ]
 
 _version_re = re.compile(r"__version__\s+=\s+(.*)")


### PR DESCRIPTION
### Description
Trying to follow the dev guide with Python 3.12.5, the install instructions were failing as `setuptools` is not specified as a dependency. This is a problem since Python 3.9 because [`setup.py` is deprecated](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html#summary).
```
Traceback (most recent call last):
  File "/Users/sawiddis/Documents/code/sql-cli/venv/bin/opensearchsql", line 5, in <module>
    from opensearch_sql_cli.main import cli
  File "/Users/sawiddis/Documents/code/sql-cli/src/opensearch_sql_cli/main.py", line 15, in <module>
    from .opensearchsql_cli import OpenSearchSqlCli
  File "/Users/sawiddis/Documents/code/sql-cli/src/opensearch_sql_cli/opensearchsql_cli.py", line 15, in <module>
    import pyfiglet
  File "/Users/sawiddis/Documents/code/sql-cli/venv/lib/python3.12/site-packages/pyfiglet/__init__.py", line 11, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

Once adding setuptools, I started getting this error for all queries:
```
AttributeError("'str' object has no attribute 'parent'")
```

Debugging further, I found a [related issue](https://github.com/pygments/pygments/issues/2027) in Pygments. I still haven't fully understood the root cause, but updating Pygments caused the issue to go away.

At some point, moving from `setup.py` per the deprecation notice may be worthwhile.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [X] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).