### PR TITLE
Main test: Update query returned records limit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requirements = [
     "click == 7.1.2",
     "prompt_toolkit == 2.0.6",
     "Pygments == 2.15.1",
-    "cli_helpers[styles] == 1.2.1",
+    "cli_helpers[styles] == 2.3.1",
     "opensearch-py == 1.0.0",
     "pyfiglet == 0.8.post1",
     "boto3 == 1.34.34",

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -63,11 +63,11 @@ class TestFormatter:
 
         expected = [
             "fetched rows / total rows = 1/1",
-            "+--------+-------+",
-            "| name   | age   |",
-            "|--------+-------|",
-            "| Tim    | 24    |",
-            "+--------+-------+",
+            "+------+-----+",
+            "| name | age |",
+            "|------+-----|",
+            "| Tim  | 24  |",
+            "+------+-----+",
         ]
         assert list(results) == expected
 
@@ -109,11 +109,11 @@ class TestFormatter:
 
         expected = [
             "fetched rows / total rows = 1/1",
-            "+--------+---------+",
-            "| name   | age     |",
-            "|--------+---------|",
-            "| Tim    | [24,25] |",
-            "+--------+---------+",
+            "+------+---------+",
+            "| name | age     |",
+            "|------+---------|",
+            "| Tim  | [24,25] |",
+            "+------+---------+",
         ]
         assert list(results) == expected
 
@@ -161,11 +161,11 @@ class TestFormatter:
         expected = [
             "fetched rows / total rows = 200/1000\n"
             "Attention: Use LIMIT keyword when retrieving more than 200 rows of data",
-            "+--------+---------+",
-            "| name   | age     |",
-            "|--------+---------|",
-            "| Tim    | [24,25] |",
-            "+--------+---------+",
+            "+------+---------+",
+            "| name | age     |",
+            "|------+---------|",
+            "| Tim  | [24,25] |",
+            "+------+---------+",
         ]
         assert list(results) == expected
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,8 @@ from src.opensearch_sql_cli.opensearchsql_cli import OpenSearchSqlCli
 
 INVALID_ENDPOINT = "http://invalid:9200"
 ENDPOINT = "http://localhost:9200"
-QUERY = "select * from %s" % TEST_INDEX_NAME
+# In OS >= 2.17, limit defaults to 10k, otherwise it's 200. Specify manually for consistency.
+QUERY = "select * from %s LIMIT 150" % TEST_INDEX_NAME
 
 
 class TestMain:
@@ -32,7 +33,7 @@ class TestMain:
                     {
                         "name": "OpenSearchIndexScan",
                         "description": {
-                            "request": 'OpenSearchQueryRequest(indexName=opensearchsql_cli_test, sourceBuilder={"from":0,"size":200,"timeout":"1m","_source":{"includes":["a"],"excludes":[]}}, searchDone=false)'
+                            "request": 'OpenSearchQueryRequest(indexName=opensearchsql_cli_test, sourceBuilder={"from":0,"size":150,"timeout":"1m","_source":{"includes":["a"],"excludes":[]}}, searchDone=false)'
                         },
                         "children": [],
                     }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -32,7 +32,7 @@ class TestMain:
                     {
                         "name": "OpenSearchIndexScan",
                         "description": {
-                            "request": 'OpenSearchQueryRequest(indexName=opensearchsql_cli_test, sourceBuilder={"from":0,"size":10000,"timeout":"1m","_source":{"includes":["a"],"excludes":[]}}, searchDone=false)'
+                            "request": 'OpenSearchQueryRequest(indexName=opensearchsql_cli_test, sourceBuilder={"from":0,"size":200,"timeout":"1m","_source":{"includes":["a"],"excludes":[]}}, searchDone=false)'
                         },
                         "children": [],
                     }

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,5 @@ deps = pytest==4.6.3
     mock==3.0.5
     pexpect==3.3
     pytest-vcr==1.0.2
-    cli_helpers[styles]==1.2.1
+    cli_helpers[styles]==2.3.1
 commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,5 @@ deps = pytest==4.6.3
     mock==3.0.5
     pexpect==3.3
     pytest-vcr==1.0.2
+    cli_helpers[styles]==1.2.1
 commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,4 @@ deps = pytest==4.6.3
     mock==3.0.5
     pexpect==3.3
     pytest-vcr==1.0.2
-    cli_helpers[styles]==2.3.1
 commands = pytest


### PR DESCRIPTION
### Description
When running in CI via `tox`, the returned limit seems to be 10000, while locally it's 200 by default. This means that one of the two test sets is always failing depending on what this number is. This PR manually specifies the limit to remove this inconsistency.

Also, side note: if you have the old `cli_helpers[styles]=1.3` locally after the `2.3` dependency was merged in main, `formatting` tests will start behaving inconsistently locally vs on CI. Pulling the new dep from main will fix it.

### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).