### PR TITLE
Add setting for using a local SQL build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ target/
 
 # Gradle
 .gradle
+META-INF/
 
 # Commands history
 .cli_history

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,5 @@
+# Gradle properties for SQL CLI
+
+# Uncomment to use local SQL project instead of published Maven artifacts
+# This is useful for development when you need to make changes in both projects
+# useLocalSql=true

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,28 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+rootProject.name = 'opensearch-sql-cli'
+
+// Optionally include the local SQL project as a composite build
+// This allows you to develop against local changes in the sql project
+// Enable by passing -PuseLocalSql=true or adding useLocalSql=true to gradle.properties
+if (settings.hasProperty('useLocalSql') && settings.useLocalSql == 'true') {
+    println "Using local SQL project for unified-query dependencies"
+
+    includeBuild('../sql') {
+        dependencySubstitution {
+            // Substitute the Maven artifacts with local project modules
+            substitute module('org.opensearch.query:unified-query-common') using project(':common')
+            substitute module('org.opensearch.query:unified-query-core') using project(':core')
+            substitute module('org.opensearch.query:unified-query-opensearch') using project(':opensearch')
+            substitute module('org.opensearch.query:unified-query-ppl') using project(':ppl')
+            substitute module('org.opensearch.query:unified-query-sql') using project(':sql')
+            substitute module('org.opensearch.query:unified-query-protocol') using project(':protocol')
+        }
+    }
+} else {
+    println "Using published Maven artifacts for unified-query dependencies"
+    println "To use local SQL project, run with -PuseLocalSql=true"
+}


### PR DESCRIPTION
### Description
Enables local development of SQL without needing to put temp changes in a feature branch upstream. Also necessary groundwork to get proper integration tests in place.
 
### Issues Resolved
N/A
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).