### PR TITLE
Increase cluster startup timeout for tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -204,12 +204,12 @@ task waitForCluster(type: Exec) {
         fi
 
         echo "Waiting for cluster to be ready..."
-        for i in {1..120}; do
+        for i in {1..300}; do
             if curl -s http://localhost:9200 > /dev/null 2>&1; then
                 echo "Cluster is ready!"
                 exit 0
             fi
-            echo "Attempt $i/120: Cluster not ready yet, waiting..."
+            echo "Attempt $i/300: Cluster not ready yet, waiting..."
             sleep 2
         done
         echo "Cluster failed to start within timeout"


### PR DESCRIPTION
### Description
Still too short when the CI runner is having a bad day (avg on good days is ~40s), will just go up to 5min

### Issues Resolved
Flaky in CI
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test and doctest
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
  - [ ] New functionality has user manual doc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).