### PR TITLE
docs: update PyPI downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 [![Latest Version](https://img.shields.io/pypi/v/opensearchsql.svg)](https://pypi.python.org/pypi/opensearchsql/)
 [![Documentation](https://img.shields.io/badge/documentation-blue.svg)](https://opensearch.org/docs/latest/search-plugins/sql/cli/)
 [![Chat](https://img.shields.io/badge/chat-on%20forums-blue)](https://forum.opensearch.org/c/plugins/sql)
-![PyPi Downloads](https://img.shields.io/pypi/dm/opensearchsql.svg)
+[![PyPI Downloads](https://static.pepy.tech/badge/opensearchsql)](https://pepy.tech/project/opensearchsql)
 ![PRs welcome!](https://img.shields.io/badge/PRs-welcome!-success)
 
 # OpenSearch SQL CLI


### PR DESCRIPTION
Summary
Closes #3.

Why
The README downloads badge currently uses the PyPI monthly downloads badge. Issue #3 notes that the previous PyPI stats-backed badge path could show invalid data because of upstream rate limiting and suggests Pepy as the alternative.

Changes
Replaced the README downloads badge with the Pepy badge for opensearchsql.
Linked the badge to the Pepy project page.
Testing
git diff --check
Known Issues
None. This is a docs-only README badge update.