### PR TITLE
Bump pathspec to 1.0.0 for black 26.3.1 compatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ mypy_extensions==1.1.0
 nh3==0.3.2
 opensearch-py==3.0.0
 packaging==25.0
-pathspec==0.12.1
+pathspec==1.0.0
 platformdirs==4.5.0
 pluggy==1.6.0
 prompt_toolkit==3.0.51


### PR DESCRIPTION
### Description
black 26.3.1 requires pathspec>=1.0.0.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] All tests pass, including unit test, integration test and doctest
- [x] New functionality has been documented.
- [x] New functionality has javadoc added
- [x] New functionality has user manual doc added
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).